### PR TITLE
Set "res.config.settings" automatically as transient model

### DIFF
--- a/bobtemplates/itpp/odoo/model/models/+model.name_underscored+.py.bob
+++ b/bobtemplates/itpp/odoo/model/models/+model.name_underscored+.py.bob
@@ -6,7 +6,7 @@
 from odoo import api, fields, models
 
 
-class {{{ model.name_camelcased }}}(models.Model):
+class {{{ model.name_camelcased }}}(models.{{{ model.name_dotted == "res.config.settings" and "Transient" or "" }}}Model):
 
 {{% if model.inherit: %}}
     _inherit = '{{{ model.name_dotted }}}'


### PR DESCRIPTION
Потому-что "res.config.settigs" это model.TransientModel, а не models.Model